### PR TITLE
[RM, RA2]: Adding GitHub Workflow and needed fixes

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -28,7 +28,7 @@ jobs:
         echo "---------------------------------- Building RM ----------------------------------------"
         echo "---------------------------------------------------------------------------------------"
         tox -e docs
-        echo "Building RM was succesfull! "
+        echo "Building RM was successful! "
         cd -
     - name: Buiding RA1 and RC1
       run: |
@@ -37,7 +37,7 @@ jobs:
         echo "---------------------------------- Building RA1 and RC1 -------------------------------"
         echo "---------------------------------------------------------------------------------------"
         tox -e docs
-        echo "Building RA1 and RC1 was succesfull! "
+        echo "Building RA1 and RC1 was successful! "
         cd - 
     - name: Building RA2
       run: |
@@ -46,7 +46,7 @@ jobs:
         echo "---------------------------------- Building RA2 ---------------------------------------"
         echo "---------------------------------------------------------------------------------------"
         tox -e docs
-        echo "Building RA2 was succesfull! "
+        echo "Building RA2 was successful! "
         cd -
     - name: Building RI1
       run: |
@@ -55,7 +55,7 @@ jobs:
         echo "---------------------------------- Building RI1 ---------------------------------------"
         echo "---------------------------------------------------------------------------------------"
         tox -e docs
-        echo "Building RI1 was succesfull! "
+        echo "Building RI1 was successful! "
         cd -
     - name: Building RI2
       run: |
@@ -64,7 +64,7 @@ jobs:
         echo "---------------------------------- Building RI2 ---------------------------------------"
         echo "---------------------------------------------------------------------------------------"
         tox -e docs
-        echo "Building RI2 was succesfull! "
+        echo "Building RI2 was successful! "
         cd -
     - name: Building RC2
       run: |
@@ -73,7 +73,7 @@ jobs:
         echo "---------------------------------- Building RC2 ---------------------------------------"
         echo "---------------------------------------------------------------------------------------"
         tox -e docs
-        echo "Building RC2 was succesfull! "
+        echo "Building RC2 was successful! "
         cd -
 
 

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -18,7 +18,8 @@ jobs:
         echo "---------------------------------- Building GOV ---------------------------------------"
         echo "---------------------------------------------------------------------------------------"
         tox -e docs
-        echo "Building GOV was succesfull! "
+        echo "Building GOV was successful! "
+
         cd -
     - name: Building RM
       run: |

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,0 +1,79 @@
+name: "Pull Request Docs Check"
+on: 
+- pull_request
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository code
+      uses: actions/checkout@v3
+    - name: Install prerequisites
+      run: | 
+        sudo apt-get --allow-releaseinfo-change update -y && sudo apt-get install -y tox
+    - name: Building GOV and common
+      run: |
+        cd doc
+        echo "---------------------------------------------------------------------------------------"
+        echo "---------------------------------- Building GOV ---------------------------------------"
+        echo "---------------------------------------------------------------------------------------"
+        tox -e docs
+        echo "Building GOV was succesfull! "
+        cd -
+    - name: Building RM
+      run: |
+        cd doc/ref_model
+        echo "---------------------------------------------------------------------------------------"
+        echo "---------------------------------- Building RM ----------------------------------------"
+        echo "---------------------------------------------------------------------------------------"
+        tox -e docs
+        echo "Building RM was succesfull! "
+        cd -
+    - name: Buiding RA1 and RC1
+      run: |
+        cd doc/ref_arch/openstack
+        echo "---------------------------------------------------------------------------------------"
+        echo "---------------------------------- Building RA1 and RC1 -------------------------------"
+        echo "---------------------------------------------------------------------------------------"
+        tox -e docs
+        echo "Building RA1 and RC1 was succesfull! "
+        cd - 
+    - name: Building RA2
+      run: |
+        cd doc/ref_arch/kubernetes
+        echo "---------------------------------------------------------------------------------------"
+        echo "---------------------------------- Building RA2 ---------------------------------------"
+        echo "---------------------------------------------------------------------------------------"
+        tox -e docs
+        echo "Building RA2 was succesfull! "
+        cd -
+    - name: Building RI1
+      run: |
+        cd doc/ref_impl/cntt-ri
+        echo "---------------------------------------------------------------------------------------"
+        echo "---------------------------------- Building RI1 ---------------------------------------"
+        echo "---------------------------------------------------------------------------------------"
+        tox -e docs
+        echo "Building RI1 was succesfull! "
+        cd -
+    - name: Building RI2
+      run: |
+        cd doc/ref_impl/cntt-ri2
+        echo "---------------------------------------------------------------------------------------"
+        echo "---------------------------------- Building RI2 ---------------------------------------"
+        echo "---------------------------------------------------------------------------------------"
+        tox -e docs
+        echo "Building RI2 was succesfull! "
+        cd -
+    - name: Building RC2
+      run: |
+        cd doc/ref_cert/RC2
+        echo "---------------------------------------------------------------------------------------"
+        echo "---------------------------------- Building RC2 ---------------------------------------"
+        echo "---------------------------------------------------------------------------------------"
+        tox -e docs
+        echo "Building RC2 was succesfull! "
+        cd -
+
+
+        

--- a/doc/ref_arch/kubernetes/chapters/chapter02.rst
+++ b/doc/ref_arch/kubernetes/chapters/chapter02.rst
@@ -1232,8 +1232,8 @@ Cloud Infrastructure Security Requirements
      - :ref:`chapters/chapter05:trusted registry`
    * - :ref:`ref_model:chapters/chapter07:open source software`
      - sec.oss.005
-     - A Software Bill of Materials (`SBOM <https://www.ntia.gov/SBOM>`__) **should** be provided or build,
-       and maintained to identify the software components and their origins.
+     - A Software Bill of Materials (`SBOM <https://ntia.gov/page/software-bill-materials>`__) **should** be provided or
+       build, and maintained to identify the software components and their origins.
      -
    * - :ref:`ref_model:chapters/chapter07:iaac - secure design and architecture stage requirements`
      - sec.arch.001

--- a/doc/ref_arch/kubernetes/conf.py
+++ b/doc/ref_arch/kubernetes/conf.py
@@ -15,7 +15,8 @@ linkcheck_ignore = [
     "https://github.com/opencontainers/runtime-spec/blob/master/config.md",
     "https://www.iso.org/obp/ui/#iso:std:iso-iec:27001:ed-2:v1:en",
     "https://www.iso.org/obp/ui/#iso:std:iso-iec:27002:ed-2:v1:en",
-    "https://www.iso.org/obp/ui/#iso:std:iso-iec:27032:ed-1:v1:en"
+    "https://www.iso.org/obp/ui/#iso:std:iso-iec:27032:ed-1:v1:en",
+    "https://ntia.gov/page/software-bill-materials"
 ]
 intersphinx_mapping = {
     'cntt': ('https://cntt.readthedocs.io/en/latest/', None),

--- a/doc/ref_arch/kubernetes/tox.ini
+++ b/doc/ref_arch/kubernetes/tox.ini
@@ -3,9 +3,9 @@ envlist = docs
 skipsdist = True
 
 [testenv:docs]
-basepython = python3.9
+basepython = python3.10
 deps =
-  -chttps://opendev.org/openstack/requirements/raw/branch/stable/xena/upper-constraints.txt
+  -chttps://opendev.org/openstack/requirements/raw/branch/stable/zed/upper-constraints.txt
   -r{toxinidir}/test-requirements.txt
 install_command = pip install {opts} {packages}
 commands =

--- a/doc/ref_model/conf.py
+++ b/doc/ref_model/conf.py
@@ -19,7 +19,8 @@ linkcheck_ignore = [
     'https://www.etsi.org',
     'https://infocentre2.gsma.com',
     'https://nplang.org',
-    'https://ntia.gov'
+    'https://ntia.gov', 
+    'https://static1.squarespace.com/static/5ad774cce74940d7115044b0/t/5db36ffa820b8d29022b6d08/1572040705841/ORAN-WG4.IOT.0-v01.00.pdf/2018/180226_NGMN_RANFSX_D1_V20_Final.pdf'
 ]
 autosectionlabel_prefix_document = True
 autosectionlabel_maxdepth = 4


### PR DESCRIPTION
This change adds a GitHub workflow to build all documents when a PR is created.
It also adds some fixes needed for a successful build:
 - [RM]: Adding ORAN WG4 docs to linkcheck ignore
 - [RA2]: Change base python to 3.10
 - [RA2]: Use zed upper-constraints
 - [RA2 Ch2]: Fixing ntia SBOM link
 - [RA2]: Adding https://ntia.gov/page/software-bill-materials to linkcheck ignore
