### PR TITLE
[RM] Added Hugepages metrics to Table 4.8

### DIFF
--- a/doc/ref_model/chapters/chapter04.rst
+++ b/doc/ref_model/chapters/chapter04.rst
@@ -272,7 +272,7 @@ or events should be collected and monitored by monitoring tools.
 |         | Capability          |           |                                                                          |
 +=========+=====================+===========+==========================================================================+
 |i.pm.001 | Host CPU usage      |nanoseconds| Per Compute node. It maps to ETSI GS NFV-TST 008 V3.5.1                  |
-|         |                     |           | :cite:p:`etsigsnfvtst008` clause 6, processor usage metric (Cloud        |
+|         |                     |           | :cite:p:`etsigsnfvtst008` processor usage metric (Cloud        |
 |         |                     |           | Infrastructure internal).                                                |
 +---------+---------------------+-----------+--------------------------------------------------------------------------+
 |i.pm.002 | Virtual compute     |nanoseconds| Per VM or Pod. It maps to ETSI GS NFV-IFA 027 v2.4.1                     |
@@ -280,7 +280,7 @@ or events should be collected and monitored by monitoring tools.
 |         | usage               |           | Infrastructure external).                                                |
 +---------+---------------------+-----------+--------------------------------------------------------------------------+
 |i.pm.003 | Host CPU            | %         | Per Compute node. It maps to ETSI GS NFV-TST 008 V3.5.1                  |
-|         | utilisation         |           | :cite:p:`etsigsnfvtst008` clause 6, processor usage metric (Cloud        |
+|         | utilisation         |           | :cite:p:`etsigsnfvtst008` processor usage metric (Cloud        |
 |         |                     |           | Infrastructure internal).                                                |
 +---------+---------------------+-----------+--------------------------------------------------------------------------+
 |i.pm.004 | Virtual compute     | %         | Per VM or Pod. It maps to ETSI GS NFV-IFA 027 v2.4.1                     |
@@ -377,6 +377,16 @@ or events should be collected and monitored by monitoring tools.
 +---------+---------------------+-----------+--------------------------------------------------------------------------+
 |i.pm.032 | Disk energy         | Watt.hour | Electrical energy consumption of a specific storage device of a node     |
 |         | consumption         | (Joule)   | since the related counter last reset (2)                                 |
++---------+---------------------+-----------+--------------------------------------------------------------------------+
+|i.pm.033 | Hugepages pool      | Integer   | the number of Hugepages currently configured in the pool, which is the   |
+|         | total               |           | total of pages available, as defined in ETSI GS NFV-TST 008 V3.5.1       |
+|         |                     |           | :cite:p:`etsigsnfvtst008`                                                |
++---------+---------------------+-----------+--------------------------------------------------------------------------+
+|i.pm.034 | Hugepages used      | Integer   | the number of used pages in the Hugepage Pool, as defined in ETSI GS     |
+|         |                     |           | NFV-TST 008 V3.5.1 :cite:p:`etsigsnfvtst008`                             |
++---------+---------------------+-----------+--------------------------------------------------------------------------+
+|i.pm.035 | Hugepages free      | Integer   | the number of free pages in the Hugepage Pool, as defined in ETSI GS     |
+|         |                     |           | NFV-TST 008 V3.5.1 :cite:p:`etsigsnfvtst008`                             |
 +---------+---------------------+-----------+--------------------------------------------------------------------------+
 
 **Table 4-8:** Internal Measurement Capabilities of Cloud Infrastructure


### PR DESCRIPTION
Fixes #3224 

Added Hugepages metrics to Table 4.8 from ETSI GS NFV-TST 008 V3.5.1 made i.pm.001 and i.pm.003 consistent by removing "clause 6"