### PR TITLE
[RA2] Update to Kubernetes 1.26

### DIFF
--- a/doc/ref_arch/kubernetes/chapters/chapter01.rst
+++ b/doc/ref_arch/kubernetes/chapters/chapter01.rst
@@ -43,7 +43,7 @@ Required component versions
 ========== ===================
 Component  Required version(s)
 ========== ===================
-Kubernetes 1.24
+Kubernetes 1.26
 ========== ===================
 
 Principles

--- a/doc/ref_arch/kubernetes/chapters/chapter03.rst
+++ b/doc/ref_arch/kubernetes/chapters/chapter03.rst
@@ -785,7 +785,7 @@ is the chosen Kubernetes Application package manager.
 Custom Resources
 ~~~~~~~~~~~~~~~~
 
-`Custom resources :cite:p:`k8s-docs-cr` are
+Custom resources :cite:p:`k8s-docs-cr` are
 extensions of the Kubernetes API that represent customizations of the Kubernetes installation. Core Kubernetes functions
 are also built using custom resources. This makes Kubernetes more modular. Two ways to add custom resources are the
 following:

--- a/doc/ref_arch/kubernetes/chapters/chapter04.rst
+++ b/doc/ref_arch/kubernetes/chapters/chapter04.rst
@@ -346,7 +346,7 @@ following specifications:
        --node-cidr-mask-size-ipv6 defaults to /24 for IPv4 and /64 for IPv6. kubelet:
        --feature-gates="IPv6DualStack=true". kube-proxy: --cluster-cidr=<IPv4 CIDR>, <IPv6 CIDR>
        --feature-gates="IPv6DualStack=true"
-       
+
        .. note::
 
         The IPv6DualStack feature is enabled by default in Kubernetes v1.21 or later.
@@ -602,7 +602,7 @@ Architecture they must be implemented according to the following specifications:
      -
      -
    * - ra2.stg.007
-     -
+     - Storage Classes
      - An implementation should use Kubernetes Storage Classes to support automation and the separation of concerns
        between providers of a service and consumers of the service.
      -

--- a/doc/ref_arch/kubernetes/chapters/chapter04.rst
+++ b/doc/ref_arch/kubernetes/chapters/chapter04.rst
@@ -346,6 +346,11 @@ following specifications:
        --node-cidr-mask-size-ipv6 defaults to /24 for IPv4 and /64 for IPv6. kubelet:
        --feature-gates="IPv6DualStack=true". kube-proxy: --cluster-cidr=<IPv4 CIDR>, <IPv6 CIDR>
        --feature-gates="IPv6DualStack=true"
+       
+       .. note::
+
+        The IPv6DualStack feature is enabled by default in Kubernetes v1.21 or later.
+
      - inf.ntw.04 in :ref:`chapters/chapter02:kubernetes architecture requirements`
      -
    * - ra2.k8s.011

--- a/doc/ref_arch/kubernetes/chapters/chapter04.rst
+++ b/doc/ref_arch/kubernetes/chapters/chapter04.rst
@@ -190,10 +190,10 @@ For a Host OS to be compliant with this Reference Architecture, it must meet the
      - tbd
    * - ra2.os.002
      - Linux kernel version
-     - A version of the Linux kernel that is compatible with kubeadm - this has been chosen as the baseline because
-       kubeadm is focused on installing and managing the lifecycle of Kubernetes and nothing else, hence it is easily
-       integrated into higher-level and more complete tooling for the full lifecycle management of the infrastructure,
-       cluster add-ons, and so on.
+     - A version of the Linux kernel that is compatible with container runtimes and kubeadm - this has been chosen as
+       the baseline because kubeadm is focused on installing and managing the lifecycle of Kubernetes and nothing else,
+       hence it is easily integrated into higher-level and more complete tooling for the full lifecycle management of
+       the infrastructure, cluster add-ons, and so on.
      - tbd
      - tbd
    * - ra2.os.003
@@ -226,8 +226,9 @@ Table 4.3 lists the kernel versions that comply with this Reference Architecture
      - Kernel Version(s)
      - Notes
    * - Linux
-     - 3.10+
-     -
+     - 4.x
+     - The overlay filesystem snapshotter, used by default by containerd, uses features that were finalized in the 4.x
+       kernel series.
    * - Windows
      - 1809 (10.0.17763)
      - For worker nodes only.

--- a/doc/ref_arch/kubernetes/chapters/chapter05.rst
+++ b/doc/ref_arch/kubernetes/chapters/chapter05.rst
@@ -51,7 +51,7 @@ secured within their perimeters. The various layers that come into picture are:
    directories of the underlying OS, etc., and running in
    privileged mode.
 -  **Pods**: A Pod represents a set of running containers on a Kubernetes Cluster.
-   Kubernetes inherently offers pod security policies that define a set of
+   Kubernetes inherently offers a PodSecurity admission controller that define a set of
    conditions that a pod needs to run with in order to be accepted into the
    system. These policies help in ensuring the necessary checks for running the
    pods.
@@ -80,7 +80,7 @@ applications:
 
    -  Use Namespaces to establish security boundaries between tenants
    -  Create and define Cluster network policies
-   -  Run a Cluster-wide pod security policy
+   -  Run a Cluster-wide Pod Security admission controller
    -  Turn on Audit Logging
    -  Separate sensitive workloads using Namespaces
    -  Secure tenant metadata Access

--- a/doc/ref_arch/kubernetes/chapters/chapter06.rst
+++ b/doc/ref_arch/kubernetes/chapters/chapter06.rst
@@ -50,7 +50,7 @@ APIs that are in following stages can be made mandatory:
 
 The Kubernetes API reference is available here :cite:p:`k8s-api-reference`.
 
-The list of :cite:t:`k8s-v1.23-api-groups` that are mandatory is:
+The list of :cite:t:`k8s-v1.26-api-groups` that are mandatory is:
 
 .. list-table:: Mandatory API Groups
    :widths: 30 30
@@ -85,7 +85,7 @@ The list of :cite:t:`k8s-v1.23-api-groups` that are mandatory is:
    * - events.k8s.io
      - v1
    * - flowcontrol.apiserver.k8s.io
-     - v1beta2, v1beta1
+     - v1beta2
    * - networking.k8s.io
      - v1
    * - node.k8s.io

--- a/doc/ref_arch/kubernetes/chapters/chapter06.rst
+++ b/doc/ref_arch/kubernetes/chapters/chapter06.rst
@@ -195,9 +195,6 @@ Auth Special Interest Group :cite:p:`k8s-api-sig-auth`
    * - Feature:NodeAuthorizer
      - X
      - Setting existing and non-existent attributes should exit with the Forbidden error, not a NotFound error
-   * - Feature:PodSecurityPolicy
-     -
-     - Should enforce the restricted policy.PodSecurityPolicy
    * - NodeFeature:FSGroup
      - X
      - ServiceAccounts should set ownership and permission when RunAsUser or FsGroup is present

--- a/doc/ref_arch/kubernetes/chapters/chapter07.rst
+++ b/doc/ref_arch/kubernetes/chapters/chapter07.rst
@@ -158,5 +158,5 @@ application requires system privileges the container either needs to run in priv
 to provide random system UIDs. Randomised UIDs result in errors when the application needs to set kernel capabilities
 (e.g., in case of VLAN trunking) or when a Pod shares data with other Pods via persistent storage. The
 "privileged mode" solution is not secure while "random UID" solution is error prone, and therefore these techniques
-should not be used. Support for proper user namespaces in Kubernetes is under implementation
-:cite:t:`kubernetes-kep-user-namespaces`.
+should not be used. Support for proper user namespaces in Kubernetes has been introduced as alpha feature in
+Kubernetes 1.25 :cite:t:`kubernetes-user-namespaces` (relevant KEP :cite:t:`kubernetes-kep-user-namespaces`).

--- a/doc/ref_arch/kubernetes/refs.bib
+++ b/doc/ref_arch/kubernetes/refs.bib
@@ -616,9 +616,9 @@
     url = {https://kubernetes.io/docs/reference/kubernetes-api/}
 }
 
-@misc{k8s-v1.23-api-groups,
+@misc{k8s-v1.26-api-groups,
     title = {Kubernetes API Groups},
-    url = {https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/
+    url = {https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/
 #-strong-api-groups-strong-}
 }
 

--- a/doc/ref_arch/kubernetes/refs.bib
+++ b/doc/ref_arch/kubernetes/refs.bib
@@ -774,6 +774,11 @@
     url = {https://docs.google.com/document/d/17LhyXsEgjNQ0NWtvqvtgJwVqdJWreizsgAZHWflgP-A/edit}
 }
 
+@misc{kubernetes-user-namespaces,
+    title = {Kubernetes Docs: User Namespaces},
+    url = {https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/}
+}
+
 @misc{kubernetes-kep-user-namespaces,
     title = {KEP-127: Support User Namespaces in stateless pods},
     url = {https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/127-user-namespaces}


### PR DESCRIPTION
fixes #3302
relevant changes:

- k8s 1.26 (EoS 2024-02-28)
- linux kernel 4+ required (due to containerd)
- ipv6 dual stack enabled by default
- updated API Groups to 1.26 - deprecated flowcontrol v1beta1
- replace podsecuritypolicy with pod security admission controller
- user namespaces now in alpha