### PR TITLE
[RM CH08] Additions of O-RAN alignment - Final

### DIFF
--- a/doc/ref_model/chapters/chapter08.rst
+++ b/doc/ref_model/chapters/chapter08.rst
@@ -879,3 +879,28 @@ Comparison of Deployment Topologies and Edge terms
 +--------+--------+--------+--------+--------+--------+--------+--------+-------+-------+-------+-------+-------+------+
 
 **Table 8-6:** Comparison of Deployment Topologies
+
+O-RAN alignment and interaction
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+O-RAN is an operator led alliance group with members from the major Telco Operators, Vendors, and other interested ecosystem participants around the specification of Open Radio Access Networks. Its task is to cloudify the 3GPP specified RAN Network Functionalities with multi-vendor open interfaces in between the Network Functions, the Cloud Infrastructure, and the management. The Service Management and Orchestration (SMO) of multiple O-Clouds is also specified including a framework for 3rd party applications (rApps). There are also a few other open interfaces that are aimed to be specified e.g., for Radio Layer 1 HW Accelerators and some low-level Radio functions.
+
+The O-RAN architecture is built up by a set of individual O-Clouds that provide the execution platforms for the Cloudified RAN Network Functions in a similar way as the Anuket NFVI infrastructure, although with O-RAN specified management interfaces. Each O-Cloud can be distributed on a set of Cloud Sites where they can provision VM and Container Node Clusters. The provisioning of O-Clouds and their resources are managed and orchestrated from a centralized RAN Service Management and Orchestration framework (SMO) over the O-RAN specified O2 interface like any other Telco Operations Support Systems (OSS).
+
+On a high-level O-RAN covers similar specification grounds as what Anuket do, but there are some noteworthy differences both on specification level and on the aim for how O-Clouds are realized. O-RAN specifies how management and orchestration of the Network Functions and Cloud Infrastructure shall be done with a set of internal Services that also have a set of interface specifications for how the rApps could enhance the management functionality. O-RAN have also articulated that O-Clouds can be distributed over multiple Cloud Sites that are stitched over an externally specified WAN interconnect transport that is not part of the O-RAN.
+
+.. figure:: ../figures/RM-Ch08-O-RAN_mappedon_Anuket-Image-1.png
+   :name: O-RAN architecture mapped onto Anuket Reference Model
+   :alt: O-RAN architecture mapped onto Anuket Reference Model
+
+   O-RAN architecture mapped onto Anuket Reference Model
+
+O-Clouds are in some ways similar to the Anuket Cloud Infrastructure with the notable differences that they have an O-RAN specified interface of how the O-Cloud infrastructure is managed (O2ims) and how workloads (e.g., whole or parts of Network Functions) are deployed on the O-Cloud clusters (O2dms). On a more detailed level the O-Clouds are internally very Layer2 (Ethernet) centric, today with strict requirements of determinism and low latency for Cloud Site internal connectivity in between the Network Functions. The O-Clouds also have the set of O-RAN specified HW Accelerators and an Acceleration Adaptation Layer (AAL) of how they are used from the Network Functions for their Radio-near functions.
+
+A potential alignment between Anuket and O-RAN's O-Cloud specifications can be investigated. This would require an analysis how an Anuket Reference Architecture based on open source technology can support the O-RAN HW Accelerators (as stated in RM Ch3 section Example of O-RAN AAL Interface :ref:`chapters/chapter03:example of o-ran acceleration abstraction layer interface` and a Layer2-centric networking infrastructure. It would enable the operators to have an internal Telco Cloud that supports both Core and RAN Network Functions, and in the extension possibly also other workloads in a shared Cloud that supports required Telco features and characteristics.
+
+.. figure:: ../figures/RM-Ch08-Anuket_as_undercloud_O-RAN-Image-1.png
+   :name: Anuket as potential under-cloud to O-Clouds in O-RAN
+   :alt: Anuket as potential under-cloud to O-Clouds in O-RAN
+
+   Anuket as potential under-cloud to O-Clouds in O-RAN


### PR DESCRIPTION
This PR describe O-RAN Cloud related parts on a very high level, its similarities and differences towards Anuket Infrastructure as well as a possible usage of Anuket as an under-cloud to O-RAN. This is a clean updated version of PR #3345 & #3346 that was also debated as #3367. These are all closed and replaced by this PR. Referenced figures in png and pptx are already uploaded since before, but png versions are attached here to make them visible in this branch. This procedure was decided on the RM meeting on May 31st.
![RM-Ch08-O-RAN_mappedon_Anuket-Image-1](https://github.com/anuket-project/anuket-specifications/assets/38792667/00e42b37-635e-4f9c-9633-4664274f7128)
![RM-Ch08-Anuket_as_undercloud_O-RAN-Image-1](https://github.com/anuket-project/anuket-specifications/assets/38792667/6131fa20-0c95-4baa-a92e-c02b2c76cca7)
