### PR TITLE
[RC1 RA1]: Add OPNFV build servers and the LFN wiki to linkcheck ignore

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -19,7 +19,8 @@ exclude_patterns = [
 linkcheck_ignore = [
     'https://github.com/cncf/telecom-user-group/blob/master/whitepaper/cloud_native_thinking_for_telecommunications.md#1.4',
     'https://static1.squarespace.com/static/5ad774cce74940d7115044b0/t/5db36ffa820b8d29022b6d08/1572040705841/ORAN-WG4.IOT.0-v01.00.pdf/2018/180226_NGMN_RANFSX_D1_V20_Final.pdf',
-    'https://ntia.gov'
+    'https://ntia.gov',
+    'https://wiki.lfnetworking.org/'
 ]
 intersphinx_mapping = {
     'ref_model': ('https://cntt.readthedocs.io/projects/rm/en/latest/', None),

--- a/doc/ref_arch/openstack/conf.py
+++ b/doc/ref_arch/openstack/conf.py
@@ -16,7 +16,15 @@ linkcheck_ignore = [
     "https://www.iso.org/obp/ui/",
     'http://127.0.0.1',
     'https://www.sdxcentral.com',
-    'https://ntia.gov'
+    'https://ntia.gov',
+# The following items are added due to the flackyness of the OPNFV build servers
+# they can be removed as soon as the build server issues are fixed.
+# Related issue: https://jira.linuxfoundation.org/plugins/servlet/desk/portal/2/IT-25549
+    'https://build.opnfv.org/',
+    'https://docs.opnfv.org/en/stable-hunter/_images/OPNFV_testing_working_group.png',
+    'http://artifacts.opnfv.org/',
+    'https://build.opnfv.org/ci/job/functest-wallaby-zip/4/console'
+###
 ]
 autosectionlabel_prefix_document = True
 autosectionlabel_maxdepth = 4

--- a/doc/ref_cert/RC2/conf.py
+++ b/doc/ref_cert/RC2/conf.py
@@ -13,7 +13,8 @@ html_theme = "piccolo_theme"
 linkcheck_ignore = [
     'http://127.0.0.1',
     'https://github.com/cncf/cnf-testsuite/',
-    'https://github.com/opencontainers/'
+    'https://github.com/opencontainers/',
+    'https://build.opnfv.org/'
 ]
 intersphinx_mapping = {
     'ref_arch_kubernetes': ('https://cntt.readthedocs.io/projects/ra2/en/latest/', None)

--- a/doc/ref_impl/cntt-ri/conf.py
+++ b/doc/ref_impl/cntt-ri/conf.py
@@ -18,7 +18,8 @@ linkcheck_ignore = [
 # Related issue: https://jira.linuxfoundation.org/plugins/servlet/desk/portal/2/IT-25549
     'https://build.opnfv.org/ci/view/cntt/',
     'http://artifacts.opnfv.org/',
-    'https://build.opnfv.org/'
+    'https://build.opnfv.org/', 
+    'https://wiki.lfnetworking.org/'
 
 ]
 intersphinx_mapping = {

--- a/doc/ref_impl/cntt-ri/conf.py
+++ b/doc/ref_impl/cntt-ri/conf.py
@@ -12,7 +12,14 @@ extensions = [
 ]
 linkcheck_ignore = [
     'http://127.0.0.1',
-    'https://trex-tgn.cisco.com'
+    'https://trex-tgn.cisco.com',
+# The following items are added due to the flackyness of the OPNFV build servers
+# they can be removed as soon as the build server issues are fixed.
+# Related issue: https://jira.linuxfoundation.org/plugins/servlet/desk/portal/2/IT-25549
+    'https://build.opnfv.org/ci/view/cntt/',
+    'http://artifacts.opnfv.org/',
+    'https://build.opnfv.org/'
+
 ]
 intersphinx_mapping = {
     'cntt': ('https://cntt.readthedocs.io/en/latest/', None),


### PR DESCRIPTION
The OPNFV build servers and the LFN wiki are flaky and cause the GitHub jobs to fail on linkcheck.