### PR TITLE
[RI2]: Update runbook and requirements

### DIFF
--- a/doc/ref_impl/cntt-ri2/chapters/chapter01.rst
+++ b/doc/ref_impl/cntt-ri2/chapters/chapter01.rst
@@ -99,14 +99,14 @@ The main communities involved in driving requirements and development of this RI
    -  The CNF Testbed is an initiative providing a framework for building and deploying technology show cases with a
       strong focus on telco platform requirements.
 
-Figure :ref:`ri2_figure_relationship-of-communities` provides an overview of the relationships among the involved communities.
+Figure :ref:`ri2_figure_relationship-of-communities` provides an overview of the relationships among the involved
+communities.
 
 .. _ri2_figure_relationship-of-communities:
 
 .. figure:: ../figures/ri2-ch01-relationship_of_communities.png
 
    Relationship of communities
-
 
 Reference Implementation Approach
 ---------------------------------

--- a/doc/ref_impl/cntt-ri2/chapters/chapter01.rst
+++ b/doc/ref_impl/cntt-ri2/chapters/chapter01.rst
@@ -19,7 +19,7 @@ The RI will be used as follows:
 -  By software vendors to be able to install Kubernetes platforms in their own environments in order to develop against
    the RI
 
-In order to promote the quick deployment of the RI and avoid duplicating effort across communities, the RI community
+To facilitate the rapid deployment of the RI and avoid redundant effort across communities, the RI community
 works closely with CNCF TUG, the Anuket Assured program, ONAP and TIP communities.
 
 Structure of the document
@@ -29,8 +29,8 @@ The document first consolidates the requirements that need to be addressed by th
 :ref:`chapters/chapter02:Reference Implementation Requirements`.
 :ref:`chapters/chapter03:Requirements for Labs` then details the requirements that need to be met in
 order for anyone to be able to install the RI, whether that be into a community lab, their own corporate or personal
-lab or some other environment such as CNF Testbed or a public cloud provider. An operational runbook is documented in
-:ref:`chapters/chapter04:Operational Runbook` to aid the deployment of the RI into a chosen
+lab or some other environment such as CNF Testbed or a public cloud provider. The 
+:ref:`chapters/chapter04:Operational Runbook` is provided to assist in the deployment of the RI into a chosen
 environment and includes step-by-step instructions for a selection of installers as well as steps on how to validate
 the deployment. Finally, :ref:`chapters/chapter05:Gap Analysis and Development` is a placeholder to
 allow the documentation of any gaps found during the development of this document and the associated artifacts.
@@ -47,7 +47,7 @@ The scope of this document is as follows:
 
 1. To generate ecosystem requirements for the establishment of the RI, including labs, tooling, installers, releases
    and automation requirements
-2. Provide a detailed description file for use by installers.
+2. Provide a detailed installation description file for use by installers.
 3. Provide detailed lab criteria and operations that are generic enough to allow any environment to be used as the
    "lab".
 4. Provide an operational runbook for the RI, which includes detailed steps for the deployment and configuration of the
@@ -99,7 +99,7 @@ The main communities involved in driving requirements and development of this RI
    -  The CNF Testbed is an initiative providing a framework for building and deploying technology show cases with a
       strong focus on telco platform requirements.
 
-Figure :ref:`ri2_figure_relationship-of-communities` gives an overview of the relationship of the communities involved.
+Figure :ref:`ri2_figure_relationship-of-communities` provides an overview of the relationships among the involved communities.
 
 .. _ri2_figure_relationship-of-communities:
 
@@ -120,7 +120,7 @@ Meaning, initially, the RI is not looking to have a single installer that can bo
 machines **and** build out the Kubernetes and other components. The primary reason for this was to ensure the loose
 coupling between the two layers, to drive the concept that RI2 is a standalone platform that can (in theory at least)
 be deployable to any infrastructure, whether that be some physical machines in a lab, or virtual machines in a private
-or public cloud environment, for example. From am implementation perspective, this means that the first step -
+or public cloud environment, for example. From an implementation perspective, this means that the first step -
 infrastructure provisioning - needs to potentially support many different infrastructures and could even be an optional
 step in the overall end-to-end deployment process if an infrastructure is provided by other means. To tightly
 intertwine the deployment of machines and the Kubernetes platform with a single installer would potentially limit the

--- a/doc/ref_impl/cntt-ri2/chapters/chapter01.rst
+++ b/doc/ref_impl/cntt-ri2/chapters/chapter01.rst
@@ -29,7 +29,7 @@ The document first consolidates the requirements that need to be addressed by th
 :ref:`chapters/chapter02:Reference Implementation Requirements`.
 :ref:`chapters/chapter03:Requirements for Labs` then details the requirements that need to be met in
 order for anyone to be able to install the RI, whether that be into a community lab, their own corporate or personal
-lab or some other environment such as CNF Testbed or a public cloud provider. The 
+lab or some other environment such as CNF Testbed or a public cloud provider. The
 :ref:`chapters/chapter04:Operational Runbook` is provided to assist in the deployment of the RI into a chosen
 environment and includes step-by-step instructions for a selection of installers as well as steps on how to validate
 the deployment. Finally, :ref:`chapters/chapter05:Gap Analysis and Development` is a placeholder to

--- a/doc/ref_impl/cntt-ri2/chapters/chapter02.rst
+++ b/doc/ref_impl/cntt-ri2/chapters/chapter02.rst
@@ -317,6 +317,12 @@ Reference Architecture Specification
       - Must support
       - Must support
       - :ref:`chapters/chapter04:Installation on Bare Metal Infrastructure`
+    * - :ref:`ref_arch_kubernetes:chapters/chapter04:Networking Solutions`
+      - ``ra2.ntw.016``
+      - Kubernetes Network Custom Resource Definition De-facto Standard compliant multiplexer / meta-plugin
+      - Must support
+      - Must support
+      - :ref:`chapters/chapter04:Installation on Bare Metal Infrastructure`
     * - :ref:`ref_arch_kubernetes:chapters/chapter04:Storage Components`
       - ``ra2.stg.004``
       - Persistent Volumes

--- a/doc/ref_impl/cntt-ri2/chapters/chapter04.rst
+++ b/doc/ref_impl/cntt-ri2/chapters/chapter04.rst
@@ -5,7 +5,7 @@ Introduction
 ------------
 
 This chapter documents the steps to deploy Kubernetes based Reference Implementation (RI-2) according to RA-2. The
-entire deployment has been tested in Anuket Labs as a part of the `Anuket Kuberef project
+deployment has been thoroughly tested in Anuket Labs as part of the `Anuket Kuberef project
 <https://wiki.anuket.io/display/HOME/Kuberef>`__, that aims to deliver RI-2 based on RA-2 specifications. The Kuberef
 project stores all the code needed to deploy RI-2 and hence serves as a reference platform for CNF vendors to develop
 and test against. Currently, Kuberef supports deployments on both baremetal, as well as pre-provisioned infrastructure
@@ -21,7 +21,7 @@ used for the Kubernetes provisioning stage and any tools used in the host provis
 Prerequisites
 -------------
 
-You need one physical server acting as a jump server along with minimum of two additional servers on which RI-2 will be
+You will need one physical server acting as a jump server along with minimum of two additional servers on which RI-2 will be
 deployed. Please refer to :ref:`chapters/chapter03:Requirements for Labs` for detailed information on
 the server and network specifications.
 
@@ -60,7 +60,7 @@ IDF includes information about network information required by the installer. Al
 VLAN, DNS, and gateway information should be defined here. The IDF file also contains configuration options for the
 Kubernetes deployment using BMRA. These options are described in greater detail below.
 
-More details regarding these descriptor files as well as their schema are very well documented in
+More details regarding these descriptor files and their schema are documented in 
 :doc:`ref_impl_cntt-ri:chapters/chapter08`.
 
 For the high availability requirement at least 3 nodes should be running as master with etcd enabled, but only a single

--- a/doc/ref_impl/cntt-ri2/chapters/chapter04.rst
+++ b/doc/ref_impl/cntt-ri2/chapters/chapter04.rst
@@ -114,7 +114,8 @@ CPU configuration.
          num_exclusive_cores: 3      # Number of CPU cores to assign to the "exclusive pool" on each node
        topology_manager:
          enable: true                # Enable Kubernetes built-in Topology Manager
-         policy: "best-effort"       # Policy to use with Topology Manager ["none", "best-effort", "restricted", "single-numa-node"]
+         policy: "best-effort"       # Policy to use with Topology Manager:
+                                     # ["none", "best-effort", "restricted", "single-numa-node"]
        tas:
          enable: true                # Enable Telemetry Aware Scheduling
          demo_policy: false          # Enable demo policy for Telemetry Aware Scheduling (default: false)

--- a/doc/ref_impl/cntt-ri2/chapters/chapter04.rst
+++ b/doc/ref_impl/cntt-ri2/chapters/chapter04.rst
@@ -21,8 +21,8 @@ used for the Kubernetes provisioning stage and any tools used in the host provis
 Prerequisites
 -------------
 
-You will need one physical server acting as a jump server along with minimum of two additional servers on which RI-2 will
-be deployed. Please refer to :ref:`chapters/chapter03:Requirements for Labs` for detailed information on
+You will need one physical server acting as a jump server along with minimum of two additional servers on which RI-2
+will be deployed. Please refer to :ref:`chapters/chapter03:Requirements for Labs` for detailed information on
 the server and network specifications.
 
 Installation of the Reference Implementation

--- a/doc/ref_impl/cntt-ri2/chapters/chapter04.rst
+++ b/doc/ref_impl/cntt-ri2/chapters/chapter04.rst
@@ -21,8 +21,8 @@ used for the Kubernetes provisioning stage and any tools used in the host provis
 Prerequisites
 -------------
 
-You will need one physical server acting as a jump server along with minimum of two additional servers on which RI-2 will be
-deployed. Please refer to :ref:`chapters/chapter03:Requirements for Labs` for detailed information on
+You will need one physical server acting as a jump server along with minimum of two additional servers on which RI-2 will
+be deployed. Please refer to :ref:`chapters/chapter03:Requirements for Labs` for detailed information on
 the server and network specifications.
 
 Installation of the Reference Implementation
@@ -60,7 +60,7 @@ IDF includes information about network information required by the installer. Al
 VLAN, DNS, and gateway information should be defined here. The IDF file also contains configuration options for the
 Kubernetes deployment using BMRA. These options are described in greater detail below.
 
-More details regarding these descriptor files and their schema are documented in 
+More details regarding these descriptor files and their schema are documented in
 :doc:`ref_impl_cntt-ri:chapters/chapter08`.
 
 For the high availability requirement at least 3 nodes should be running as master with etcd enabled, but only a single


### PR DESCRIPTION
Misclose the last PR and open a new one.
It updates RI2 requirements based on RA2 Nile, and modifies the runbook.