### PR TITLE
[RA1]: Fixing the readthedocs build

### DIFF
--- a/doc/ref_arch/openstack/.readthedocs.yaml
+++ b/doc/ref_arch/openstack/.readthedocs.yaml
@@ -1,0 +1,15 @@
+version: 2
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.10"
+
+# Build from the root directory with Sphinx
+sphinx:
+  configuration: conf.py
+
+# Explicitly set the version of Python and its requirements
+python:
+  install:
+    - requirements: test-requirements.txt

--- a/doc/ref_arch/openstack/test-requirements.txt
+++ b/doc/ref_arch/openstack/test-requirements.txt
@@ -4,6 +4,6 @@
 sphinx!=1.6.6,!=1.6.7,!=2.1.0,!=3.0.0,!=3.4.2 # BSD
 sphinx-rtd-theme  # MIT
 doc8 # Apache-2.0
-piccolo-theme
-sphinxcontrib-bibtex
-pybtex
+piccolo-theme==0.16.0 # MIT
+sphinxcontrib-bibtex==2.5.0
+pybtex==0.24.0


### PR DESCRIPTION
Readthedocs recommends the usage of a .readthedocs.yaml file for the configuration of the readthedocs service. Nailing down the dependency versions fixes a version conflict bug (and results in reproduceable builds)
This is the carved out piece from #3380