### PR TITLE
[RA2] add LB specs

### DIFF
--- a/doc/ref_arch/kubernetes/chapters/chapter04.rst
+++ b/doc/ref_arch/kubernetes/chapters/chapter04.rst
@@ -547,32 +547,32 @@ the following specifications:
      - Kubernetes Load Balancer
      - The networking solution deployed within the implementation must include a L4 (TCP/UDP - except QUIC) Load Balancer to steer inbound traffic across the primary interfaces of multiple CNF pods.
      - inf.ntw.15 in :ref:`chapters/chapter02:kubernetes architecture requirements`
-     - 
+     -
    * - ra2.ntw.018
      - Kubernetes Load Balancer - API
      - The Load Balancer solution deployed per `ra2.ntw.017` must support the Service type Loadbalancer API.
      - inf.ntw.15 in :ref:`chapters/chapter02:kubernetes architecture requirements`
-     - 
+     -
    * - ra2.ntw.019
      - Kubernetes Load Balancer - API
      - The Load Balancer solution deployed per `ra2.ntw.017` may support the Gateway API additionally.
      - inf.ntw.15 in :ref:`chapters/chapter02:kubernetes architecture requirements`
-     - 
+     -
    * - ra2.ntw.020
      - Kubernetes Load Balancer - Advertisements
      - The Load Balancer solution deployed per `ra2.ntw.017` must be capable of advertising the IPs of Services to external networks.
      - inf.ntw.15 in :ref:`chapters/chapter02:kubernetes architecture requirements`
-     - 
+     -
    * - ra2.ntw.021
      - Kubernetes Load Balancer - Active/active Multipath
      - The Load Balancer solution deployed per `ra2.ntw.017` must support multi-path advertisements in an active/active design, allowing the same service IP to be advertised by multiple cluster nodes.
      - inf.ntw.15 in :ref:`chapters/chapter02:kubernetes architecture requirements`
-     - 
+     -
    * - ra2.ntw.022
      - Kubernetes Load Balancer - High Availability
      - The networking solution deployed per `ra2.ntw.017` must be capable of fast failover. Upon node or pod failure, it must redirect traffic (i.e., advertisements/routes must be updated) in less than 5 seconds.
      - inf.ntw.15 in :ref:`chapters/chapter02:kubernetes architecture requirements`
-     - 
+     -
 
 Storage components
 ------------------

--- a/doc/ref_arch/kubernetes/chapters/chapter04.rst
+++ b/doc/ref_arch/kubernetes/chapters/chapter04.rst
@@ -545,7 +545,7 @@ the following specifications:
      - :cite:t:`anuket-ri2` Chapter 4, section Installation on Bare Metal Infratructure
    * - ra2.ntw.017
      - Kubernetes Load Balancer
-     - The networking solution deployed within the implementation must include a L4 (TCP/UDP) Load Balancer to steer inbound traffic across the primary interfaces of multiple CNF pods.
+     - The networking solution deployed within the implementation must include a L4 (TCP/UDP - except QUIC) Load Balancer to steer inbound traffic across the primary interfaces of multiple CNF pods.
      - inf.ntw.15 in :ref:`chapters/chapter02:kubernetes architecture requirements`
      - 
    * - ra2.ntw.018

--- a/doc/ref_arch/kubernetes/chapters/chapter04.rst
+++ b/doc/ref_arch/kubernetes/chapters/chapter04.rst
@@ -543,6 +543,21 @@ the following specifications:
        :cite:t:`multi-net-spec`.
      - gen.ost.01 in :ref:`chapters/chapter02:kubernetes architecture requirements`
      - :cite:t:`anuket-ri2` Chapter 4, section Installation on Bare Metal Infratructure
+   * - ra2.ntw.017
+     - Kubernetes Load Balancer - API
+     - The networking solution deployed within the implementation must include a L4 (TCP/UDP) Load Balancer to steer inbound traffic across the primary interfaces of multiple CNF pods. The solution must support Service type Loadbalancer API and may support the Gateway API additionally.
+     - inf.ntw.15 in :ref:`chapters/chapter02:kubernetes architecture requirements`
+     - 
+   * - ra2.ntw.018
+     - Kubernetes Load Balancer - Advertisements & Active/active Multipath
+     - The networking solution deployed within the implementation must include a L4 (TCP/UDP) Load Balancer capable of advertising the IPs of Services to external networks. To achieve an active/active design, the advertisements must support multi-path, allowing the same service IP to be advertised by multiple cluster nodes (where pods serving traffic reside) as next-hops.
+     - inf.ntw.15 in :ref:`chapters/chapter02:kubernetes architecture requirements`
+     - 
+   * - ra2.ntw.019
+     - Kubernetes Load Balancer - High Availability
+     - The networking solution deployed within the implementation must include a L4 (TCP/UDP) Load Balancer capable of fast failover. Upon node or pod failure, traffic should be redirected (i.e. advertisements/routes must be updated) in less than 5 seconds to prevent application failure.
+     - inf.ntw.15 in :ref:`chapters/chapter02:kubernetes architecture requirements`
+     - 
 
 Storage components
 ------------------

--- a/doc/ref_arch/kubernetes/chapters/chapter04.rst
+++ b/doc/ref_arch/kubernetes/chapters/chapter04.rst
@@ -544,18 +544,33 @@ the following specifications:
      - gen.ost.01 in :ref:`chapters/chapter02:kubernetes architecture requirements`
      - :cite:t:`anuket-ri2` Chapter 4, section Installation on Bare Metal Infratructure
    * - ra2.ntw.017
-     - Kubernetes Load Balancer - API
-     - The networking solution deployed within the implementation must include a L4 (TCP/UDP) Load Balancer to steer inbound traffic across the primary interfaces of multiple CNF pods. The solution must support Service type Loadbalancer API and may support the Gateway API additionally.
+     - Kubernetes Load Balancer
+     - The networking solution deployed within the implementation must include a L4 (TCP/UDP) Load Balancer to steer inbound traffic across the primary interfaces of multiple CNF pods.
      - inf.ntw.15 in :ref:`chapters/chapter02:kubernetes architecture requirements`
      - 
    * - ra2.ntw.018
-     - Kubernetes Load Balancer - Advertisements & Active/active Multipath
-     - The networking solution deployed within the implementation must include a L4 (TCP/UDP) Load Balancer capable of advertising the IPs of Services to external networks. To achieve an active/active design, the advertisements must support multi-path, allowing the same service IP to be advertised by multiple cluster nodes (where pods serving traffic reside) as next-hops.
+     - Kubernetes Load Balancer - API
+     - The Load Balancer solution deployed per `ra2.ntw.017` must support the Service type Loadbalancer API.
      - inf.ntw.15 in :ref:`chapters/chapter02:kubernetes architecture requirements`
      - 
    * - ra2.ntw.019
+     - Kubernetes Load Balancer - API
+     - The Load Balancer solution deployed per `ra2.ntw.017` may support the Gateway API additionally.
+     - inf.ntw.15 in :ref:`chapters/chapter02:kubernetes architecture requirements`
+     - 
+   * - ra2.ntw.020
+     - Kubernetes Load Balancer - Advertisements
+     - The Load Balancer solution deployed per `ra2.ntw.017` must be capable of advertising the IPs of Services to external networks.
+     - inf.ntw.15 in :ref:`chapters/chapter02:kubernetes architecture requirements`
+     - 
+   * - ra2.ntw.021
+     - Kubernetes Load Balancer - Active/active Multipath
+     - The Load Balancer solution deployed per `ra2.ntw.017` must support multi-path advertisements in an active/active design, allowing the same service IP to be advertised by multiple cluster nodes.
+     - inf.ntw.15 in :ref:`chapters/chapter02:kubernetes architecture requirements`
+     - 
+   * - ra2.ntw.022
      - Kubernetes Load Balancer - High Availability
-     - The networking solution deployed within the implementation must include a L4 (TCP/UDP) Load Balancer capable of fast failover. Upon node or pod failure, traffic should be redirected (i.e. advertisements/routes must be updated) in less than 5 seconds to prevent application failure.
+     - The networking solution deployed per `ra2.ntw.017` must be capable of fast failover. Upon node or pod failure, it must redirect traffic (i.e., advertisements/routes must be updated) in less than 5 seconds.
      - inf.ntw.15 in :ref:`chapters/chapter02:kubernetes architecture requirements`
      - 
 


### PR DESCRIPTION
fixes #3316 
have added 3 specs for load balancer:

- one for the LB itself and its API
- one for active active via BGP
- one for fast failover / HA - ie to prevent ARP VIPs

may also add:

- session stickiness / persistence
- SCTP
- multihoming / VRF support