### PR TITLE
[RM Ch 07] Update link to Australia ISM framework

### DIFF
--- a/doc/ref_model/chapters/chapter07.rst
+++ b/doc/ref_model/chapters/chapter07.rst
@@ -1054,7 +1054,7 @@ The ACCC is responsible for the economic regulation of the communications sector
 National Broadband Network (NBN), broadcasting and content sectors.
 
 From the cloud services security perspective, the Australian Cyber Security Centre (ACSC) produced
-`Information Security Manual (ISM) <https://www.cyber.gov.au/acsc/view-all-content/ism/>`__,
+`Information Security Manual (ISM) < https://www.cyber.gov.au/resources-business-and-government/essential-cyber-security/ism/>`__,
 is of particular importance. The purpose of the ISM is to outline a cyber security framework that organisations can
 apply, using their risk management framework, to protect their information and systems from cyber threats. The ISM is
 intended for Chief Information Security Officers, Chief Information Officers, cyber security professionals and


### PR DESCRIPTION
Updating the link to Australia Government ISM (Information Security Manual) to https://www.cyber.gov.au/resources-business-and-government/essential-cyber-security/ism/